### PR TITLE
Notation for "(f : _ -> _) \in lfun mu p"

### DIFF
--- a/theories/hoelder.v
+++ b/theories/hoelder.v
@@ -716,10 +716,8 @@ Canonical Lequiv_canonical :=
 Local Open Scope quotient_scope.
 
 Definition LspaceType := {eq_quot Lequiv}.
-Canonical LspaceType_quotType := [the quotType _ of LspaceType].
-Canonical LspaceType_eqType := [the eqType of LspaceType].
-Canonical LspaceType_choiceType := [the choiceType of LspaceType].
-Canonical LspaceType_eqQuotType := [the eqQuotType Lequiv of LspaceType].
+HB.instance Definition _ := Choice.on LspaceType.
+HB.instance Definition _ := EqQuotient.on LspaceType.
 
 Lemma LequivP (f g : LfunType mu p1) :
   reflect (f = g %[ae mu]) (f == g %[mod LspaceType]).

--- a/theories/hoelder.v
+++ b/theories/hoelder.v
@@ -45,11 +45,6 @@ From mathcomp Require Import lebesgue_integral numfun exp convex ess_sup_inf.
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
-Import Order.TTheory GRing.Theory Num.Def Num.Theory.
-Import numFieldTopology.Exports.
-
-Local Open Scope classical_set_scope.
-Local Open Scope ring_scope.
 
 Reserved Notation "'N[ mu ]_ p [ F ]"
   (at level 5, F at level 36, mu at level 10,
@@ -59,7 +54,15 @@ Reserved Notation "'N_ p [ F ]"
   (at level 5, F at level 36, format "'[' ''N_' p '/  ' [ F ] ']'").
 Reserved Notation "mu .-Lspace p" (at level 4, format "mu .-Lspace  p").
 
+Reserved Notation "f '\in' 'lfun' mu p" (mu, p at level 9).
+
 Declare Scope Lnorm_scope.
+
+Import Order.TTheory GRing.Theory Num.Def Num.Theory.
+Import numFieldTopology.Exports.
+
+Local Open Scope classical_set_scope.
+Local Open Scope ring_scope.
 
 Local Open Scope ereal_scope.
 HB.lock Definition Lnorm {d} {T : measurableType d} {R : realType}
@@ -744,13 +747,15 @@ Proof. by move=> x /andP[]. Qed.
 
 End lfun_pred.
 
+Notation "f '\in' 'lfun' mu p" := (in_mem (f : _ -> _) (mem (lfun mu p))).
+
 Section lfun.
 Context d (T : measurableType d) (R : realType).
 Variables (mu : {measure set T -> \bar R}) (p : \bar R) (p1 : (1 <= p)%E).
 
-Notation lfun := (@lfun _ T R mu p).
+Notation lfunp := (@lfun _ T R mu p).
 Section Sub.
-Context (f : T -> R) (fP : f \in lfun).
+Context (f : T -> R) (fP : f \in lfunp).
 Definition lfun_Sub1_subproof :=
   @isMeasurableFun.Build d _ T R f (set_mem (sub_lfun_mfun fP)).
 #[local] HB.instance Definition _ := lfun_Sub1_subproof.
@@ -764,16 +769,16 @@ Definition lfun_Sub : LfunType mu p1 := f.
 End Sub.
 
 Lemma lfun_rect (K : LfunType mu p1 -> Type) :
-  (forall f (Pf : f \in lfun), K (lfun_Sub Pf)) -> forall u, K u.
+  (forall f (Pf : f \in lfunp), K (lfun_Sub Pf)) -> forall u, K u.
 Proof.
 move=> Ksub [f [[Pf1] [Pf2]]].
-have Pf : f \in lfun by apply/andP; rewrite ?inE.
+have Pf : f \in lfunp by apply/andP; rewrite ?inE.
 have -> : Pf1 = set_mem (sub_lfun_mfun Pf) by [].
 have -> : Pf2 = set_mem (sub_lfun_finlfun Pf) by [].
 exact: Ksub.
 Qed.
 
-Lemma lfun_valP f (Pf : f \in lfun) : lfun_Sub Pf = f :> (_ -> _).
+Lemma lfun_valP f (Pf : f \in lfunp) : lfun_Sub Pf = f :> (_ -> _).
 Proof. by []. Qed.
 
 HB.instance Definition _ :=
@@ -794,7 +799,7 @@ HB.instance Definition _ := @isLfun.Build d T R mu p p1 (cst 0) lfuny0.
 Lemma mfunP (f : {mfun T >-> R}) : (f : T -> R) \in mfun.
 Proof. exact: valP. Qed.
 
-Lemma lfunP (f : LfunType mu p1) : (f : T -> R) \in lfun.
+Lemma lfunP (f : LfunType mu p1) : (f : T -> R) \in lfunp.
 Proof. exact: valP. Qed.
 
 Lemma mfun_scaler_closed : scaler_closed (@mfun _ _ T R).
@@ -827,16 +832,16 @@ case: p p1 f => //[r r1 f|? f].
   by rewrite normrZ EFinM.
 Qed.
 
-Lemma lfun_oppr_closed : oppr_closed lfun.
+Lemma lfun_oppr_closed : oppr_closed lfunp.
 Proof.
 move=> f /andP[mf /[!inE] lf].
 by rewrite rpredN/= mf/= inE/= /finite_norm oppr_Lnorm.
 Qed.
 
-HB.instance Definition _ := GRing.isOppClosed.Build _ lfun
+HB.instance Definition _ := GRing.isOppClosed.Build _ lfunp
   lfun_oppr_closed.
 
-Lemma lfun_submod_closed : submod_closed lfun.
+Lemma lfun_submod_closed : submod_closed lfunp.
 Proof.
 split.
   by rewrite -[0]/(cst 0); exact: lfunP.
@@ -851,7 +856,7 @@ apply: mem_set => /=; apply: (le_lt_trans (eminkowski _ _ _ _)) => //.
   by rewrite LnormZ lte_mul_pinfty// ?lee_fin//; exact: lfuny.
 Qed.
 
-HB.instance Definition _ := GRing.isSubmodClosed.Build _ _ lfun
+HB.instance Definition _ := GRing.isSubmodClosed.Build _ _ lfunp
   lfun_submod_closed.
 
 HB.instance Definition _ := [SubChoice_isSubLmodule of LfunType mu p1 by <:].
@@ -915,8 +920,7 @@ Definition LType1 := LType mu (@lexx _ _ 1%E).
 
 Definition LType2 := LType mu (lee1n 2).
 
-Lemma lfun_integrable (f : {mfun T >-> R}) r :
-  1 <= r -> (f : T -> R) \in lfun mu r%:E ->
+Lemma lfun_integrable (f : {mfun T >-> R}) r : 1 <= r -> f \in lfun mu r%:E ->
   mu.-integrable setT (fun x => (`|f x| `^ r)%:E).
 Proof.
 rewrite inE => r0 /andP[_]; rewrite inE/= => lpf.
@@ -930,8 +934,8 @@ apply: le_lt_trans.
 by under eq_integral => x _ do rewrite gee0_abs ?lee_fin ?powR_ge0//.
 Qed.
 
-Lemma lfun1_integrable (f : {mfun T >-> R}) :
-  (f : T -> R) \in lfun mu 1 -> mu.-integrable setT (EFin \o f).
+Lemma lfun1_integrable (f : {mfun T >-> R}) : f \in lfun mu 1 ->
+  mu.-integrable setT (EFin \o f).
 Proof.
 move=> /lfun_integrable => /(_ (lexx _)).
 under eq_fun => x do rewrite powRr1//.
@@ -941,9 +945,8 @@ rewrite (le_lt_trans _ fley)//=.
 by under [leRHS]eq_integral => x _ do rewrite normr_id.
 Qed.
 
-Lemma lfun2_integrable_sqr (f : {mfun T >-> R}) :
-  (f : T -> R) \in lfun mu 2%:E ->
-    mu.-integrable [set: T] (EFin \o (fun x => f x ^+ 2)).
+Lemma lfun2_integrable_sqr (f : {mfun T >-> R}) : f \in lfun mu 2%:E ->
+  mu.-integrable [set: T] (EFin \o (fun x => f x ^+ 2)).
 Proof.
 rewrite inE => /andP[_]; rewrite inE/= => l2f.
 apply/integrableP; split.
@@ -967,8 +970,8 @@ rewrite gt0_ler_poweR//.
 Qed.
 
 Lemma lfun2M2_1 (f g : {mfun T >-> R}) :
-    (f : T -> R) \in lfun mu 2%:E -> (g : T -> R) \in lfun mu 2%:E ->
-  (f \* g : T -> R) \in lfun mu 1.
+    f \in lfun mu 2%:E -> g \in lfun mu 2%:E ->
+  f \* g \in lfun mu 1.
 Proof.
 move=> l2f l2g.
 rewrite inE; apply/andP; split; rewrite inE//=.
@@ -980,8 +983,8 @@ by move: l2f; rewrite inE => /andP[_]; rewrite inE/=.
 by move: l2g; rewrite inE => /andP[_]; rewrite inE/=.
 Qed.
 
-Lemma lfunp_scale (f : {mfun T >-> R}) a r :
-  1 <= r -> (f : T -> R) \in lfun mu r%:E -> (a \o* f) \in lfun mu r%:E.
+Lemma lfunp_scale (f : {mfun T >-> R}) a r : 1 <= r -> f \in lfun mu r%:E ->
+  (a \o* f) \in lfun mu r%:E.
 Proof.
 move=> r1 lpf.
 rewrite inE; apply/andP; split; rewrite inE//=.

--- a/theories/probability.v
+++ b/theories/probability.v
@@ -163,7 +163,7 @@ Context d (T : measurableType d) (R : realType) (P : probability T R).
 Lemma expectation_def (X : {RV P >-> R}) : 'E_P[X] = (\int[P]_w (X w)%:E)%E.
 Proof. by rewrite unlock. Qed.
 
-Lemma expectation_fin_num (X : {RV P >-> R}) : (X : T -> R) \in lfun P 1 ->
+Lemma expectation_fin_num (X : {RV P >-> R}) : X \in lfun P 1 ->
   'E_P[X] \is a fin_num.
 Proof. by move=> ?; rewrite unlock integral_fune_fin_num ?lfun1_integrable. Qed.
 
@@ -180,12 +180,12 @@ move: iX => /integrableP[? Xoo]; rewrite (le_lt_trans _ Xoo)// unlock.
 exact: le_trans (le_abse_integral _ _ _).
 Qed.
 
-Lemma expectationZl (X : {RV P >-> R}) (iX : (X : T -> R) \in lfun P 1)
-  (k : R) : 'E_P[k \o* X] = k%:E * 'E_P [X].
+Lemma expectationZl (X : {RV P >-> R}) (iX : X \in lfun P 1) (k : R) :
+  'E_P[k \o* X] = k%:E * 'E_P [X].
 Proof. by rewrite unlock muleC -integralZr ?lfun1_integrable. Qed.
 
-Lemma expectation_ge0 (X : {RV P >-> R}) :
-  (forall x, 0 <= X x)%R -> 0 <= 'E_P[X].
+Lemma expectation_ge0 (X : {RV P >-> R}) : (forall x, 0 <= X x)%R ->
+  0 <= 'E_P[X].
 Proof.
 by move=> ?; rewrite unlock integral_ge0// => x _; rewrite lee_fin.
 Qed.
@@ -204,24 +204,21 @@ move=> mX mY X0 Y0 XY; rewrite unlock ae_ge0_le_integral => //.
   by apply: XYN => /=; apply: contra_not h; rewrite lee_fin.
 Qed.
 
-Lemma expectationD (X Y : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 1 -> (Y : T -> R) \in lfun P 1 ->
+Lemma expectationD (X Y : {RV P >-> R}) : X \in lfun P 1 -> Y \in lfun P 1 ->
   'E_P[X \+ Y] = 'E_P[X] + 'E_P[Y].
 Proof. by move=> ? ?; rewrite unlock integralD_EFin ?lfun1_integrable. Qed.
 
-Lemma expectationB (X Y : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 1 -> (Y : T -> R) \in lfun P 1 ->
+Lemma expectationB (X Y : {RV P >-> R}) : X \in lfun P 1 -> Y \in lfun P 1 ->
   'E_P[X \- Y] = 'E_P[X] - 'E_P[Y].
 Proof. by move=> ? ?; rewrite unlock integralB_EFin ?lfun1_integrable. Qed.
 
 Lemma expectation_sum (X : seq {RV P >-> R}) :
-    (forall Xi, Xi \in X -> (Xi : T -> R) \in lfun P 1) ->
+    (forall Xi, Xi \in X -> Xi \in lfun P 1) ->
   'E_P[\sum_(Xi <- X) Xi] = \sum_(Xi <- X) 'E_P[Xi].
 Proof.
 elim: X => [|X0 X IHX] intX; first by rewrite !big_nil expectation_cst.
-have intX0 : (X0 : T -> R) \in lfun P 1.
-  by apply: intX; rewrite in_cons eqxx.
-have {}intX Xi : Xi \in X -> (Xi : T -> R) \in lfun P 1.
+have intX0 : X0 \in lfun P 1 by apply: intX; rewrite in_cons eqxx.
+have {}intX Xi : Xi \in X -> Xi \in lfun P 1.
   by move=> XiX; apply: intX; rewrite in_cons XiX orbT.
 by rewrite !big_cons expectationD ?IHX ?lfun_sum.
 Qed.
@@ -244,9 +241,7 @@ Local Open Scope ereal_scope.
 Context d (T : measurableType d) (R : realType) (P : probability T R).
 
 Lemma covarianceE (X Y : {mfun T >-> R}) :
-    (X : T -> R) \in lfun P 1 ->
-    (Y : T -> R) \in lfun P 1 ->
-    ((X * Y)%R : T -> R) \in lfun P 1 ->
+    X \in lfun P 1 -> Y \in lfun P 1 -> (X * Y)%R \in lfun P 1 ->
   covariance P X Y = 'E_P[X * Y] - 'E_P[X] * 'E_P[Y].
 Proof.
 move=> l1X l1Y l1XY.
@@ -268,9 +263,7 @@ by rewrite unlock; congr expectation; apply/funeqP => x /=; rewrite mulrC.
 Qed.
 
 Lemma covariance_fin_num (X Y : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 1 ->
-    (Y : T -> R) \in lfun P 1 ->
-    ((X * Y)%R : T -> R) \in lfun P 1 ->
+    X \in lfun P 1 -> Y \in lfun P 1 -> (X * Y)%R \in lfun P 1 ->
   covariance P X Y \is a fin_num.
 Proof.
 by move=> ? ? ?; rewrite covarianceE// fin_numB fin_numM expectation_fin_num.
@@ -287,9 +280,7 @@ Lemma covariance_cst_r (X : {RV P >-> R}) c : covariance P X (cst c) = 0.
 Proof. by rewrite covarianceC covariance_cst_l. Qed.
 
 Lemma covarianceZl a (X Y : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 1 ->
-    (Y : T -> R) \in lfun P 1 ->
-    ((X * Y)%R : T -> R) \in lfun P 1 ->
+    X \in lfun P 1 -> Y \in lfun P 1 -> (X * Y)%R \in lfun P 1 ->
   covariance P (a \o* X)%R Y = a%:E * covariance P X Y.
 Proof.
 move=> X1 Y1 XY1.
@@ -303,9 +294,7 @@ by rewrite -muleA -muleBr// fin_num_adde_defr// expectation_fin_num.
 Qed.
 
 Lemma covarianceZr a (X Y : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 1 ->
-    (Y : T -> R) \in lfun P 1 ->
-    ((X * Y)%R : T -> R) \in lfun P 1 ->
+    X \in lfun P 1 -> Y \in lfun P 1 -> (X * Y)%R \in lfun P 1 ->
   covariance P X (a \o* Y)%R = a%:E * covariance P X Y.
 Proof.
 move=> X1 Y1 XY1.
@@ -313,9 +302,7 @@ by rewrite [in RHS]covarianceC covarianceC covarianceZl; last rewrite mulrC.
 Qed.
 
 Lemma covarianceNl (X Y : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 1 ->
-    (Y : T -> R) \in lfun P 1 ->
-    ((X * Y)%R : T -> R) \in lfun P 1 ->
+    X \in lfun P 1 -> Y \in lfun P 1 -> (X * Y)%R \in lfun P 1 ->
   covariance P (\- X)%R Y = - covariance P X Y.
 Proof.
 move=> X1 Y1 XY1.
@@ -324,25 +311,19 @@ by rewrite covarianceZl// EFinN mulNe mul1e.
 Qed.
 
 Lemma covarianceNr (X Y : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 1 ->
-    (Y : T -> R) \in lfun P 1 ->
-    ((X * Y)%R : T -> R) \in lfun P 1 ->
+    X \in lfun P 1 -> Y \in lfun P 1 -> (X * Y)%R \in lfun P 1 ->
   covariance P X (\- Y)%R = - covariance P X Y.
 Proof. by move=> X1 Y1 XY1; rewrite !(covarianceC X) covarianceNl 1?mulrC. Qed.
 
 Lemma covarianceNN (X Y : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 1 ->
-    (Y : T -> R) \in lfun P 1 ->
-    ((X * Y)%R : T -> R) \in lfun P 1 ->
+    X \in lfun P 1 -> Y \in lfun P 1 -> (X * Y)%R \in lfun P 1 ->
   covariance P (\- X)%R (\- Y)%R = covariance P X Y.
 Proof.
 by move=> ? ? ?; rewrite covarianceNl//= ?covarianceNr ?oppeK ?mulrN//= ?rpredN.
 Qed.
 
 Lemma covarianceDl (X Y Z : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 2%:E ->
-    (Y : T -> R) \in lfun P 2%:E ->
-    (Z : T -> R) \in lfun P 2%:E ->
+    X \in lfun P 2%:E -> Y \in lfun P 2%:E -> Z \in lfun P 2%:E ->
   covariance P (X \+ Y)%R Z = covariance P X Z + covariance P Y Z.
 Proof.
 move=> X2 Y2 Z2.
@@ -360,18 +341,14 @@ by rewrite addeACA 2?covarianceE.
 Qed.
 
 Lemma covarianceDr (X Y Z : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 2%:E ->
-    (Y : T -> R) \in lfun P 2%:E ->
-    (Z : T -> R) \in lfun P 2%:E ->
+    X \in lfun P 2%:E -> Y \in lfun P 2%:E -> Z \in lfun P 2%:E ->
   covariance P X (Y \+ Z)%R = covariance P X Y + covariance P X Z.
 Proof.
 by move=> X2 Y2 Z2; rewrite covarianceC covarianceDl ?(covarianceC X) 1?mulrC.
 Qed.
 
 Lemma covarianceBl (X Y Z : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 2%:E ->
-    (Y : T -> R) \in lfun P 2%:E ->
-    (Z : T -> R) \in lfun P 2%:E ->
+    X \in lfun P 2%:E -> Y \in lfun P 2%:E -> Z \in lfun P 2%:E ->
   covariance P (X \- Y)%R Z = covariance P X Z - covariance P Y Z.
 Proof.
 move=> X2 Y2 Z2.
@@ -383,9 +360,7 @@ by rewrite -[(X \- Y)%R]/(X \+ (\- Y))%R covarianceDl ?covarianceNl ?rpredN.
 Qed.
 
 Lemma covarianceBr (X Y Z : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 2%:E ->
-    (Y : T -> R) \in lfun P 2%:E ->
-    (Z : T -> R) \in lfun P 2%:E ->
+    X \in lfun P 2%:E -> Y \in lfun P 2%:E -> Z \in lfun P 2%:E ->
   covariance P X (Y \- Z)%R = covariance P X Y - covariance P X Z.
 Proof.
 move=> X2 Y2 Z2.
@@ -405,16 +380,14 @@ Context d (T : measurableType d) (R : realType) (P : probability T R).
 Definition variance (X : T -> R) := covariance P X X.
 Local Notation "''V_' P [ X ]" := (variance X).
 
-Lemma varianceE (X : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 2%:E ->
+Lemma varianceE (X : {RV P >-> R}) : X \in lfun P 2%:E ->
   'V_P[X] = 'E_P[X ^+ 2] - ('E_P[X]) ^+ 2.
 Proof.
 move=> X2.
 by rewrite /variance covarianceE ?lfun2M2_1// lfun_inclusion12 ?fin_num_measure.
 Qed.
 
-Lemma variance_fin_num (X : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 2%:E ->
+Lemma variance_fin_num (X : {RV P >-> R}) : X \in lfun P 2%:E ->
   'V_P[X] \is a fin_num.
 Proof.
 move=> X2.
@@ -433,8 +406,7 @@ rewrite [X in 'E_P[X]](_ : _ = cst 0%R) ?expectation_cst//.
 by apply/funext => x; rewrite /GRing.exp/GRing.mul/= subrr mulr0.
 Qed.
 
-Lemma varianceZ a (X : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 2%:E ->
+Lemma varianceZ a (X : {RV P >-> R}) : X \in lfun P 2%:E ->
   'V_P[(a \o* X)%R] = (a ^+ 2)%:E * 'V_P[X].
 Proof.
 move=> X2.
@@ -444,17 +416,14 @@ rewrite /variance covarianceZl ?covarianceZr ?lfun2M2_1 ?lfunp_scale ?ler1n//.
 by rewrite muleA EFinM.
 Qed.
 
-Lemma varianceN (X : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 2%:E ->
+Lemma varianceN (X : {RV P >-> R}) : X \in lfun P 2%:E ->
   'V_P[(\- X)%R] = 'V_P[X].
 Proof.
 move=> X2.
 by rewrite /variance covarianceNN ?lfun2M2_1 ?lfun_inclusion12 ?fin_num_measure.
 Qed.
 
-Lemma varianceD (X Y : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 2%:E ->
-    (Y : T -> R) \in lfun P 2%:E ->
+Lemma varianceD (X Y : {RV P >-> R}) : X \in lfun P 2%:E -> Y \in lfun P 2%:E ->
   'V_P[X \+ Y]%R = 'V_P[X] + 'V_P[Y] + 2%:E * covariance P X Y.
 Proof.
 move=> X2 Y2.
@@ -468,9 +437,7 @@ rewrite (covarianceC P Y X) [LHS]addeA [LHS](ACl (1*4*(2*3)))/=.
 by rewrite -[2%R]/(1 + 1)%R EFinD muleDl ?mul1e// covariance_fin_num.
 Qed.
 
-Lemma varianceB (X Y : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 2%:E ->
-    (Y : T -> R) \in lfun P 2%:E ->
+Lemma varianceB (X Y : {RV P >-> R}) : X \in lfun P 2%:E -> Y \in lfun P 2%:E ->
   'V_P[(X \- Y)%R] = 'V_P[X] + 'V_P[Y] - 2%:E * covariance P X Y.
 Proof.
 move=> X2 Y2.
@@ -482,16 +449,14 @@ rewrite -[(X \- Y)%R]/(X \+ (\- Y))%R.
 by rewrite varianceD/= ?varianceN ?covarianceNr ?muleN ?rpredN.
 Qed.
 
-Lemma varianceD_cst_l c (X : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 2%:E ->
+Lemma varianceD_cst_l c (X : {RV P >-> R}) : X \in lfun P 2%:E ->
   'V_P[(cst c \+ X)%R] = 'V_P[X].
 Proof.
 move=> X2.
 by rewrite varianceD ?lfun_cst// variance_cst add0e covariance_cst_l mule0 adde0.
 Qed.
 
-Lemma varianceD_cst_r (X : {RV P >-> R}) c :
-    (X : T -> R) \in lfun P 2%:E ->
+Lemma varianceD_cst_r (X : {RV P >-> R}) c : X \in lfun P 2%:E ->
   'V_P[(X \+ cst c)%R] = 'V_P[X].
 Proof.
 move=> X2.
@@ -499,24 +464,21 @@ have -> : (X \+ cst c = cst c \+ X)%R by apply/funeqP => x /=; rewrite addrC.
 exact: varianceD_cst_l.
 Qed.
 
-Lemma varianceB_cst_l c (X : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 2%:E ->
+Lemma varianceB_cst_l c (X : {RV P >-> R}) : X \in lfun P 2%:E ->
   'V_P[(cst c \- X)%R] = 'V_P[X].
 Proof.
 move=> X2; rewrite -[(cst c \- X)%R]/(cst c \+ (\- X))%R.
 by rewrite varianceD_cst_l/= ?rpredN// varianceN.
 Qed.
 
-Lemma varianceB_cst_r (X : {RV P >-> R}) c :
-    (X : T -> R) \in lfun P 2%:E ->
+Lemma varianceB_cst_r (X : {RV P >-> R}) c : X \in lfun P 2%:E ->
   'V_P[(X \- cst c)%R] = 'V_P[X].
 Proof.
 by move=> X2; rewrite -[(X \- cst c)%R]/(X \+ (cst (- c)))%R varianceD_cst_r.
 Qed.
 
 Lemma covariance_le (X Y : {RV P >-> R}) :
-    (X : T -> R) \in lfun P 2%:E ->
-    (Y : T -> R) \in lfun P 2%:E ->
+    X \in lfun P 2%:E -> Y \in lfun P 2%:E ->
   covariance P X Y <= sqrte 'V_P[X] * sqrte 'V_P[Y].
 Proof.
 move=> X2 Y2.
@@ -614,7 +576,7 @@ by move=> /le_trans; apply; rewrite /variance [in leRHS]unlock.
 Qed.
 
 Lemma cantelli (X : {RV P >-> R}) (lambda : R) :
-    (X : T -> R) \in lfun P 2%:E -> (0 < lambda)%R ->
+    X \in lfun P 2%:E -> (0 < lambda)%R ->
   P [set x | lambda%:E <= (X x)%:E - 'E_P[X]]
   <= (fine 'V_P[X] / (fine 'V_P[X] + lambda^2))%:E.
 Proof.
@@ -623,8 +585,7 @@ move=> /(lfun_inclusion12 (fin_num_measure P _ measurableT)) X1 lambda_gt0.
 have finEK : (fine 'E_P[X])%:E = 'E_P[X] by rewrite fineK ?expectation_fin_num.
 have finVK : (fine 'V_P[X])%:E = 'V_P[X] by rewrite fineK ?variance_fin_num.
 pose Y := (X \- cst (fine 'E_P[X]))%R.
-have Y2 : (Y : T -> R) \in lfun P 2%:E.
-  by rewrite /Y rpredB ?lee1n//= => _; rewrite lfun_cst.
+have Y2 : Y \in lfun P 2%:E by rewrite rpredB ?lee1n//= => _; rewrite lfun_cst.
 have EY : 'E_P[Y] = 0.
   rewrite expectationB ?lfun_cst//= expectation_cst.
   by rewrite finEK subee// expectation_fin_num.


### PR DESCRIPTION
Avoids having to constantly repeat the `: T -> R` in all `f \in lfun mu p`